### PR TITLE
Enabling DI scenarios

### DIFF
--- a/Nina.Demo.Tinyurl/Global.asax.cs
+++ b/Nina.Demo.Tinyurl/Global.asax.cs
@@ -17,7 +17,10 @@ namespace Nina.Demo.Tinyurl
     {
         public static void RegisterRoutes(RouteCollection routes)
         {
-            routes.Add(new MountingPoint<TinyUrl>("/"));
+            routes.Add(new Route("{resource}.axd/{*pathInfo}", new StopRoutingHandler()));
+            routes.Add(new Route("favicon.ico", new StopRoutingHandler()));
+
+            routes.Add(new MountingPoint<TinyUrl>("/", () => new TinyUrl(new Urls())));
         }
 
         protected void Application_Start()

--- a/Nina.Demo.Tinyurl/Nina.Demo.Tinyurl.csproj
+++ b/Nina.Demo.Tinyurl/Nina.Demo.Tinyurl.csproj
@@ -80,7 +80,7 @@
         <WebProjectProperties>
           <UseIIS>False</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>23687</DevelopmentServerPort>
+          <DevelopmentServerPort>56628</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:8080/tinyurl</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/Nina.Demo.Tinyurl/TinyUrl.cs
+++ b/Nina.Demo.Tinyurl/TinyUrl.cs
@@ -13,18 +13,17 @@ namespace Nina.Demo.Tinyurl
 {
     public class TinyUrl : Nina.Application
     {
-        private static readonly Urls Urls = new Urls();
-        public TinyUrl()
+        public TinyUrl(Urls urls)
         {
             Get("/", (m,c) => Text("<html><body>Tiny url!<form method='post'><input type='text' name='url'/><input type='submit' value='tiny!'/></form></body></html>"));
             
             Post("/", (m,c)=>
             {
-                var url = Urls.Save(c.Request.Form["url"]);
+                var url = urls.Save(c.Request.Form["url"]);
                 return Text(string.Format("<html><body>Your url: <a href='{0}'>{0}</a></body></html>", c.Request.Url +url));
             });
 
-            Get("/{tinyurl}", (m, c) => Redirect(Urls.Get(m["tinyurl"])) );
+            Get("/{tinyurl}", (m, c) => Redirect(urls.Get(m["tinyurl"])) );
         }
     }
 

--- a/Nina.Demo/Nina.Demo.csproj
+++ b/Nina.Demo/Nina.Demo.csproj
@@ -132,7 +132,7 @@
         <WebProjectProperties>
           <UseIIS>False</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>23683</DevelopmentServerPort>
+          <DevelopmentServerPort>56631</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:8080/va2</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/Nina/Routing/MountedRouteHandler.cs
+++ b/Nina/Routing/MountedRouteHandler.cs
@@ -7,19 +7,21 @@
 // See LICENSE.txt for details.
 //
 #endregion
+
+using System;
 using System.Web;
 using System.Web.Routing;
 
 namespace Nina.Routing
 {
-	internal class MountedRouteHandler<T> : IRouteHandler where T : NinaBaseHandler, new()
+	internal class MountedRouteHandler<T> : IRouteHandler where T : NinaBaseHandler
 	{
 		private readonly RouteBase _route;
 		private readonly string _mountingPoint;
 	    private readonly T _httpHandler;
 	    private readonly string _absolute;
 
-	    public MountedRouteHandler(RouteBase route, string mountingPoint)
+	    public MountedRouteHandler(RouteBase route, string mountingPoint, Func<T> applicationFactory)
 		{
 			_route = route;
 			_mountingPoint = mountingPoint;
@@ -27,7 +29,10 @@ namespace Nina.Routing
             //optimization: we have the same handler instance for all requests
 	        _absolute = VirtualPathUtility.ToAbsolute(_mountingPoint);
             
-            _httpHandler = new T { Route = _route, MountingPointVirtual = _mountingPoint, MountingPointPath = _absolute };
+            _httpHandler = applicationFactory();
+            _httpHandler.Route = _route;
+            _httpHandler.MountingPointVirtual = _mountingPoint;
+            _httpHandler.MountingPointPath = _absolute;
 		}
 
 		public IHttpHandler GetHttpHandler(RequestContext requestContext)


### PR DESCRIPTION
Simple change - added the ability to pass in a factory expression to a MountingPoint in order to enable DI techniques to be used. The old API remains - internally it just sets the expression to "Activator.CreateInstance<T>()". Since this only happens once during startup of the application it won't impact runtime performance.

Those using an IoC container would be able to specify something like () => container.Resolve<MyApplication>() as their factory expression, with the caveat that the application instance will be created once and reused, so dependency lifetimes need to be taken into account. Containers like Autofac and others provide this capability in the form of expressing dependencies as Func<MyDependency> and your code can simply invoke that function to get a new instance of the dependency each time it is needed.

Also - added a couple of route exclusions to the TinyUrl sample so that others would know how to ignore routes who might be coming from ASP.NET MVC-land and are used to the "IgnoreRoute" extension method they provide. Just thought it might help...

Thanks for a great framework - really enjoying using it!
Matt
